### PR TITLE
Remove "debugger" flag from items.js

### DIFF
--- a/lib/items.js
+++ b/lib/items.js
@@ -45,7 +45,7 @@ class Items extends Component {
     if(items.length) {
       numberOfItems = items.length < 4 ? items.length : 3
     }
-    debugger
+    
     if(!this.props.useSelectHeight) {
       height = Constants.OPTION_HEIGHT
     }


### PR DESCRIPTION
There is a `debugger` flag inside de items.js in production, so every tume I try to use yout lib its frozening my app whe the compiler reach the debugger flag.
So I removed it.